### PR TITLE
[GAZ-253] fixes from govstack closedloop and mojaloop testing

### DIFF
--- a/src/main/java/hu/dpc/phee/operator/entity/batch/BatchRepository.java
+++ b/src/main/java/hu/dpc/phee/operator/entity/batch/BatchRepository.java
@@ -3,6 +3,7 @@ package hu.dpc.phee.operator.entity.batch;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BatchRepository extends JpaRepository<Batch, Long>, JpaSpecificationExecutor {
@@ -11,4 +12,5 @@ public interface BatchRepository extends JpaRepository<Batch, Long>, JpaSpecific
     Optional<Batch> findByBatchId(String batchId);
     Optional<Batch> findBySubBatchId(String subBatchId);
     Optional<Batch> findByBatchIdAndSubBatchIdIsNull(String batchId);
+    List<Batch> findAllByBatchIdAndSubBatchIdIsNull(String batchId);
 }

--- a/src/main/java/hu/dpc/phee/operator/streams/RecordParser.java
+++ b/src/main/java/hu/dpc/phee/operator/streams/RecordParser.java
@@ -232,6 +232,20 @@ public class RecordParser {
             transactionRequestRepository.save(transactionRequest);
         } else if ("BATCH".equalsIgnoreCase(flowType)) {
             Batch batch = inflightBatchManager.retrieveOrCreateBatch(bpmn, sample);
+            // Duplicate parent check BEFORE applying transformer to avoid JPA auto-flush writing
+            // the in-memory batchId to DB before the duplicate lookup query runs (which would
+            // cause NonUniqueResultException since both rows would then match the WHERE clause).
+            if (variableName.equals("batchId") && batch.getSubBatchId() == null && batch.getBatchId() == null) {
+                List<Batch> existingParents = batchRepository.findAllByBatchIdAndSubBatchIdIsNull(value);
+                if (!existingParents.isEmpty() && !existingParents.get(0).getId().equals(batch.getId())) {
+                    logger.info("Duplicate parent batch row detected for batchId={}, deleting orphan row id={}, using parent id={}",
+                            value, batch.getId(), existingParents.get(0).getId());
+                    batchRepository.delete(batch);
+                    // storeBatchId so future lookups for this workflowInstanceKey find the existing parent
+                    inflightBatchManager.storeBatchId(workflowInstanceKey, value);
+                    return;
+                }
+            }
             matchingTransformers.forEach(transformer -> applyTransformer(batch, variableName, value, transformer));
             batchRepository.save(batch);
             //if (!config.get().getName().equalsIgnoreCase("bulk_processor")) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -100,29 +100,45 @@ transfer:
         - field: paymentMode
           variableName: transactionList
           jsonPath: $.payment_mode
-#    - name: bulk_connector_closedloop
-#      direction: UNKNOWN
-#      type: BATCH
-#      transformers:
-#        - field: batchId
-#          variableName: batchId
-#        - field: payerFsp
-#          variableName: tenantId
-#        - field: requestFile
-#          variableName: filename
-#        - field: registeringInstitutionId
-#          variableName: registeringInstituteId
-#        - field: correlationId
-#          variableName: clientCorrelationId
-#        - field: requestId
-#          variableName: transactionList
-#          jsonPath: $.request_id
-#        - field: note
-#          variableName: transactionList
-#          jsonPath: $.note
-#        - field: paymentMode
-#          variableName: transactionList
-#          jsonPath: $.payment_mode
+    - name: bulk_connector_closedloop
+      direction: UNKNOWN
+      type: BATCH
+      transformers:
+        - field: batchId
+          variableName: batchId
+        - field: payerFsp
+          variableName: tenantId
+        - field: requestFile
+          variableName: filename
+        - field: registeringInstitutionId
+          variableName: registeringInstituteId
+        - field: correlationId
+          variableName: clientCorrelationId
+        - field: requestId
+          variableName: transactionList
+          jsonPath: $.request_id
+        - field: note
+          variableName: transactionList
+          jsonPath: $.note
+        - field: paymentMode
+          variableName: transactionList
+          jsonPath: $.payment_mode
+        - field: totalTransactions
+          variableName: totalTransactions
+        - field: completed
+          variableName: completedTransaction
+        - field: failed
+          variableName: failedTransactions
+        - field: ongoing
+          variableName: ongoingTransactions
+        - field: totalAmount
+          variableName: totalAmount
+        - field: completedAmount
+          variableName: completedAmount
+        - field: failedAmount
+          variableName: failedAmount
+        - field: ongoingAmount
+          variableName: ongoingAmount
     - name: inbound_transfer_mifos
       direction: INCOMING
       type: TRANSACTION-REQUEST


### PR DESCRIPTION
## Fix duplicate parent batch rows for closedloop sub-processes

- RecordParser: Detects orphan parent rows before applying the transformer (avoiding a JPA auto-flush race) by checking batch.getBatchId() == null combined with findAllByBatchIdAndSubBatchIdIsNull(). Deletes orphan rows created by the sub-process before the parent batchId variable propagates through Zeebe.
- BatchRepository: Adds findAllByBatchIdAndSubBatchIdIsNull() query. application-local.yml: Enables the bulk_connector_closedloop Kafka Streams transformer with correct count field mappings.

https://mifosforge.jira.com/browse/GAZ-253

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Design related bullet points or design document link related to this PR added in the description above. 

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing
